### PR TITLE
Add RFC2217 support to serialupdi

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ pymcuprog supports:
 * EDBG - on-board debugger on Xplained Pro/Ultra
 * mEDBG - on-board debugger on Xplained Mini/Nano
 * JTAGICE3 (firmware version 3.0 or newer)
+* Serial (TTY/COM) and RFC2217 compatible devices (serialupdi)
 
 Although not all functionality is provided on all debuggers/boards.  See device support section below.
 


### PR DESCRIPTION
This commit provides a feature to open different serial device types based on the port name. In particular RFC2217 can be used without any change allowing to use TCP-to-TTY bridges for programming of UPDI devices.