### PR TITLE
Add UART DTR control support via command-line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+install.cmd
+test.cmd
+__pycache__

--- a/pymcuprog/nvmserialupdi.py
+++ b/pymcuprog/nvmserialupdi.py
@@ -54,12 +54,13 @@ class NvmAccessProviderSerial(NvmAccessProvider):
         """
         port = transport.serialport
         timeout = transport.timeout
+        dtr = transport.dtr
         baudrate = transport.baudrate
         self.avr = None
         self.options = options
         NvmAccessProvider.__init__(self, device_info)
         self.dut = Dut(device_info)
-        self.avr = UpdiApplication(port, baudrate, self.dut, timeout=timeout)
+        self.avr = UpdiApplication(port, baudrate, self.dut, timeout=timeout, dtr=dtr)
         # Read the device info to set up the UPDI stack variant
         self.avr.read_device_info()
 

--- a/pymcuprog/pymcuprog.py
+++ b/pymcuprog/pymcuprog.py
@@ -252,6 +252,11 @@ def main():
                         default="1.0",
                         help="Timeout for read operations to complete (when using -t uart).  Defaults to 1.0s")
 
+    parser.add_argument("--uart-dtr",
+                        type=int,
+                        default=-1,
+                        help="Set serial port DTR line high (0) or low (1). Default for all connections is low.")
+
     parser.add_argument("-i", "--interface",
                         type=str,
                         help="Programming interface to use")

--- a/pymcuprog/pymcuprog_main.py
+++ b/pymcuprog/pymcuprog_main.py
@@ -505,7 +505,7 @@ def _setup_tool_connection(args):
     if args.tool == "uart":
         baudrate = _clk_as_int(args)
         # Embedded GPIO/UART tool (eg: raspberry pi) => no USB connection
-        toolconnection = ToolSerialConnection(serialport=args.uart, baudrate=baudrate, timeout=args.uart_timeout)
+        toolconnection = ToolSerialConnection(serialport=args.uart, baudrate=baudrate, timeout=args.uart_timeout, dtr=args.uart_dtr)
     else:
         usb_serial = args.serialnumber
         product = args.tool

--- a/pymcuprog/serialupdi/application.py
+++ b/pymcuprog/serialupdi/application.py
@@ -79,12 +79,12 @@ class UpdiApplication:
     :type timeout: int
     """
 
-    def __init__(self, serialport, baud, device=None, timeout=None):
+    def __init__(self, serialport, baud, device=None, timeout=None, dtr=-1):
         self.logger = getLogger(__name__)
         self.device = device
         # Build the UPDI stack:
         # Create a physical
-        self.phy = UpdiPhysical(serialport, baud, timeout)
+        self.phy = UpdiPhysical(serialport, baud, timeout, dtr)
 
         # Create a DL - use 24-bit until otherwise known
         datalink = UpdiDatalink24bit()

--- a/pymcuprog/serialupdi/link.py
+++ b/pymcuprog/serialupdi/link.py
@@ -57,12 +57,19 @@ class UpdiDatalink:
         """
         self._init_session_parameters()
         # Check
-        if not self._check_datalink():
-            # Send double break if all is not well, and re-check
-            self.updi_phy.send_double_break()
-            self._init_session_parameters()
-            if not self._check_datalink():
-                raise PymcuprogSerialUpdiError("UPDI initialisation failed")
+        retries = 0
+        try:
+            while not self._check_datalink():
+                # Send double break if all is not well, and re-check
+                self.updi_phy.send_double_break()
+                if retries == 0:
+                    print("Waiting for device...")
+                retries += 1
+                if retries > 100:
+                    raise PymcuprogSerialUpdiError("UPDI initialisation failed")
+                self._init_session_parameters()
+        except KeyboardInterrupt:
+            raise PymcuprogSerialUpdiError("UPDI initialisation failed")
 
     def _check_datalink(self):
         """

--- a/pymcuprog/serialupdi/physical.py
+++ b/pymcuprog/serialupdi/physical.py
@@ -15,7 +15,7 @@ class UpdiPhysical:
     PDI physical driver using a given serial port at a given baud
     """
 
-    def __init__(self, port, baud=DEFAULT_SERIALUPDI_BAUD, timeout=None):
+    def __init__(self, port, baud=DEFAULT_SERIALUPDI_BAUD, timeout=None, dtr=-1):
         """
         Serial port physical interface for UPDI
 
@@ -42,13 +42,14 @@ class UpdiPhysical:
             self.timeout = timeout
         else:
             self.timeout = 1.0
+        self.dtr = dtr
         self.ser = None
 
-        self.initialise_serial(self.port, self.baud, self.timeout)
+        self.initialise_serial(self.port, self.baud, self.timeout, self.dtr)
         # send an initial break as handshake
         self.send([constants.UPDI_BREAK])
 
-    def initialise_serial(self, port, baud, timeout):
+    def initialise_serial(self, port, baud, timeout, dtr):
         """
         Standard serial port initialisation
 
@@ -66,6 +67,9 @@ class UpdiPhysical:
         except SerialException:
             self.logger.error("Unable to open serial port '%s'", port)
             raise
+
+        if dtr != -1:
+            self.ser.dtr = (dtr != 0)
 
     def _loginfo(self, msg, data):
         if data and isinstance(data[0], str):
@@ -109,7 +113,7 @@ class UpdiPhysical:
 
         # Re-init at the real baud
         temporary_serial.close()
-        self.initialise_serial(self.port, self.baud, self.timeout)
+        self.initialise_serial(self.port, self.baud, self.timeout, self.dtr)
 
     def send(self, command):
         """

--- a/pymcuprog/toolconnection.py
+++ b/pymcuprog/toolconnection.py
@@ -34,7 +34,7 @@ class ToolSerialConnection(ToolConnection):
     """
     serialport = None
 
-    def __init__(self, serialport="COM1", baudrate=DEFAULT_SERIALUPDI_BAUD, timeout=None):
+    def __init__(self, serialport="COM1", baudrate=DEFAULT_SERIALUPDI_BAUD, timeout=None, dtr=-1):
         """
         :param serialport: Serial port name to connect to.
         :type serialport: str
@@ -43,7 +43,9 @@ class ToolSerialConnection(ToolConnection):
         :param timeout: timeout value for serial reading.
             When UPDI is not enabled, attempting to read will return after this timeout period.
         :type timeout: float
+        :type timeout: int
         """
         self.serialport = serialport
         self.baudrate = baudrate
         self.timeout = timeout
+        self.dtr = dtr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pyserial
+IntelHex
+PyYAML
+appdirs
+pyedbglib>=2.24


### PR DESCRIPTION
See #34 

Documentation and some code paths might be incomplete, but it works for me for writing a program to the device, with DTR set to both high or low.